### PR TITLE
Update Projector for 0.9.0 OF API

### DIFF
--- a/src/ofxRay/Plane.cpp
+++ b/src/ofxRay/Plane.cpp
@@ -161,7 +161,7 @@ namespace ofxRay {
 	void Plane::setUp(const ofVec3f& up) {
 		this->up = up;
 		this->up = this->up - this->up * this->up.dot(this->normal);
-		this->up = this->normal.crossed(this->getRight());
+		this->up = this->normal.getCrossed(this->getRight());
 		this->up.normalize();
 	}
 
@@ -256,7 +256,7 @@ namespace ofxRay {
 
 
 	ofVec3f Plane::getRight() const {
-		return up.crossed(normal).normalize();
+		return up.getCrossed(normal).normalize();
 	}
 
 	Ray Plane::getUpRay() const {

--- a/src/ofxRay/Projector.cpp
+++ b/src/ofxRay/Projector.cpp
@@ -41,8 +41,8 @@ namespace ofxRay {
 		glMultMatrixf(getViewMatrix().getInverse().getPtr());
 		glMultMatrixf(getClippedProjectionMatrix().getInverse().getPtr());
 		drawBox->draw();
-		ofLine(ofVec3f(0.0f,0.0f,-1.0f), ofVec3f(2.0f,0.0f,-1.0f));
-		ofLine(ofVec3f(0.0f,0.0f,-1.0f), ofVec3f(0.0f,2.0f,-1.0f));
+		ofDrawLine(ofVec3f(0.0f,0.0f,-1.0f), ofVec3f(2.0f,0.0f,-1.0f));
+		ofDrawLine(ofVec3f(0.0f,0.0f,-1.0f), ofVec3f(0.0f,2.0f,-1.0f));
 		ofPopMatrix();
 	
 		ofPopStyle();
@@ -255,12 +255,12 @@ rays.push_back(Ray(s, t, ofColor(255.0f * (it->x + 1.0f) / 2.0f, 255.0f * (it->y
 		plane.addIndex(1);
 		plane.addIndex(3);
 		
-		image.getTextureReference().bind();
+		image.getTexture().bind();
 		ofPushMatrix();
 		glMultMatrixf(inversed.getPtr());
 		plane.draw();
 		ofPopMatrix();
-		image.getTextureReference().unbind();
+		image.getTexture().unbind();
 	}
 	
 	void Projector::beginAsCamera() const {

--- a/src/ofxRay/Ray.cpp
+++ b/src/ofxRay/Ray.cpp
@@ -40,7 +40,7 @@ namespace ofxRay {
 	
 		ofPushMatrix();
 		ofTranslate(s);
-		ofSphere(0.01);
+		ofDrawSphere(0.01);
 		ofPopMatrix();
 	
 		if (infinite) {
@@ -51,13 +51,13 @@ namespace ofxRay {
 				ofPushStyle();
 				ofSetLineWidth(1.0f);
 				ofSetColor(255,255,255);
-				ofLine(s-100*t, s+100*t);
+				ofDrawLine(s-100*t, s+100*t);
 				ofPopStyle();
 			}
 		
 		
 			ofSetLineWidth(width==0.0f ? 1.0f : width);
-			ofLine(s-1000*t, s+1000*t);
+			ofDrawLine(s-1000*t, s+1000*t);
 		}
 	
 		//arrow


### PR DESCRIPTION
This PR updates a few deprecated calls:

- A compile error on `getTextureReference()`
- Deprecation warnings on `ofLine(...)` , `ofSphere(...)` and `ofVec3f::crossed()`