### PR TITLE
Return ofVec3f copy in Ray::getEnd()

### DIFF
--- a/src/ofxRay/Ray.cpp
+++ b/src/ofxRay/Ray.cpp
@@ -178,7 +178,7 @@ namespace ofxRay {
 		return this->s;
 	}
 
-	const ofVec3f & Ray::getEnd() const {
+	const ofVec3f Ray::getEnd() const {
 		return this->t + this->s;
 	}
 

--- a/src/ofxRay/Ray.h
+++ b/src/ofxRay/Ray.h
@@ -41,7 +41,7 @@ namespace ofxRay {
 		void setTranmissionVector(const ofVec3f &);
 
 		const ofVec3f & getStart() const;
-		const ofVec3f & getEnd() const;
+		const ofVec3f getEnd() const;
 		const ofVec3f & getTransmissionVector() const;
 
 		Ray operator*(float other) const;


### PR DESCRIPTION
Fixes #9 and ruins [visual symmetry of ofxRay.h](https://github.com/admsyn/ofxRay/blob/855de50b1c9a69d930d573588666092ef8141d55/src/ofxRay/Ray.h#L43-L45) :)